### PR TITLE
Add safety check to repair

### DIFF
--- a/repair.py
+++ b/repair.py
@@ -31,6 +31,7 @@ parser.add_argument('--repair-interval', type=str, default=repair['repairInterva
 parser.add_argument('--run-interval', type=str, default=repair['runInterval'], help='Optional interval in smart format (e.g. 1w2d3h4m5s) to run the repair process.')
 parser.add_argument('--mode', type=str, choices=['symlink', 'file'], default='symlink', help='Choose repair mode: `symlink` or `file`. `symlink` to repair broken symlinks and `file` to repair missing files.')
 parser.add_argument('--include-unmonitored', action='store_true', help='Include unmonitored media in the repair process')
+parser.add_argument('--safety-check-script', type=str, default=repair['safetyCheckScript'], help='Python code to be evaluated and return boolean for whether torrent mount is working or not. mountTorrentsPath will be replaced by Realdebrid/Torbox mount path.')
 args = parser.parse_args()
 
 _print = print
@@ -58,9 +59,9 @@ except Exception as e:
 def safety_check(mountTorrentsPath):
     try:
         # Default script to check if the number of directories is greater than zero
-        default_script = "len([name for name in os.listdir(mountTorrentsPath) if os.path.isdir(os.path.join(mountTorrentsPath, name))]) > 0"
-        safety_check_script = os.getenv('SAFETY_CHECK_SCRIPT', default_script)
-        safety_check_passed = eval(safety_check_script, {"os": os, "mountTorrentsPath": mountTorrentsPath})
+        #default_script = "len([name for name in os.listdir(mountTorrentsPath) if os.path.isdir(os.path.join(mountTorrentsPath, name))]) > 0"
+        #safety_check_script = os.getenv('SAFETY_CHECK_SCRIPT', default_script)
+        safety_check_passed = eval(args.safety_check_script, {"os": os, "mountTorrentsPath": mountTorrentsPath})
         return safety_check_passed
     except Exception as e:
         print(f"Error checking torrent mount or evaluating safety check script: {safety_check_script}  exception: {e}")

--- a/repair.py
+++ b/repair.py
@@ -57,11 +57,13 @@ except Exception as e:
 
 def safety_check(mount_torrents_path):
     try:
-        folder_count = len([name for name in os.listdir(mount_torrents_path) if os.path.isdir(os.path.join(mount_torrents_path, name))])
-        return folder_count > 0
-
+        # Default script to check if the number of directories is greater than zero
+        default_script = "len([name for name in os.listdir(mount_torrents_path) if os.path.isdir(os.path.join(mount_torrents_path, name))]) > 0"
+        safety_check_script = os.getenv('SAFETY_CHECK_SCRIPT', default_script)
+        safety_check_passed = eval(safety_check_script)
+        return safety_check_passed
     except Exception as e:
-        print(f"Error checking torrent mount path: {e}")
+        print(f"Error checking torrent mount or evaluating safety check script: {e}")
         return False
 
 def main():

--- a/repair.py
+++ b/repair.py
@@ -58,13 +58,10 @@ except Exception as e:
 
 def safety_check(mountTorrentsPath):
     try:
-        # Default script to check if the number of directories is greater than zero
-        #default_script = "len([name for name in os.listdir(mountTorrentsPath) if os.path.isdir(os.path.join(mountTorrentsPath, name))]) > 0"
-        #safety_check_script = os.getenv('SAFETY_CHECK_SCRIPT', default_script)
         safety_check_passed = eval(args.safety_check_script, {"os": os, "mountTorrentsPath": mountTorrentsPath})
         return safety_check_passed
     except Exception as e:
-        print(f"Error checking torrent mount or evaluating safety check script: {safety_check_script}  exception: {e}")
+        print(f"Error checking torrent mount or evaluating safety check script [{safety_check_script}] for mount path [{mountTorrentsPath}] : exception: {e}")
         return False
 
 def main():

--- a/repair.py
+++ b/repair.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import argparse
 import time
 import traceback

--- a/repair.py
+++ b/repair.py
@@ -55,15 +55,15 @@ except Exception as e:
     print(f"Invalid interval format for run interval: {args.run_interval}")
     exit(1)
 
-def safety_check(mount_torrents_path):
+def safety_check(mountTorrentsPath):
     try:
         # Default script to check if the number of directories is greater than zero
-        default_script = "len([name for name in os.listdir(mount_torrents_path) if os.path.isdir(os.path.join(mount_torrents_path, name))]) > 0"
+        default_script = "len([name for name in os.listdir(mountTorrentsPath) if os.path.isdir(os.path.join(mountTorrentsPath, name))]) > 0"
         safety_check_script = os.getenv('SAFETY_CHECK_SCRIPT', default_script)
-        safety_check_passed = eval(safety_check_script)
+        safety_check_passed = eval(safety_check_script, {"os": os, "mountTorrentsPath": mountTorrentsPath})
         return safety_check_passed
     except Exception as e:
-        print(f"Error checking torrent mount or evaluating safety check script: {e}")
+        print(f"Error checking torrent mount or evaluating safety check script: {safety_check_script}  exception: {e}")
         return False
 
 def main():
@@ -81,9 +81,9 @@ def main():
 
             # perform a "Safety check" to make sure that the torrents folder is mounted to prevent deleting everything in *arrs
             # we do this inside of the loop because the mount could drop at any time; so, best to check with each iteration
-            if not safety_check(realdebrid['mountTorrentsPath']):
-                print(f"Safety check failed: couldn't verify torrent folder is mounted: {realdebrid['mountTorrentsPath']}")
-                discordError(f"[{args.mode}] An error occurred while processing {media.title}: Safety check failed: couldn't verify torrent folder is mounted", realdebrid['mountTorrentsPath'])
+            if ((realdebrid['enabled'] and not safety_check(realdebrid['mountTorrentsPath'])) or (torbox['enabled'] and not safety_check(torbox['mountTorrentsPath']))):
+                print(f"Safety check failed: couldn't verify torrent folder is mounted")
+                discordError(f"[{args.mode}] An error occurred while processing {media.title}: Safety check failed: couldn't verify torrent folder is mounted")
                 if repairIntervalSeconds > 0:
                     time.sleep(repairIntervalSeconds)
                 continue

--- a/repair.py
+++ b/repair.py
@@ -73,7 +73,7 @@ def main():
             mount_torrents_path = realdebrid['mountTorrentsPath']
             if not os.path.exists(mount_torrents_path):
                 print(f"Path to mounted torrents does not exist: {mount_torrents_path}")
-                discordError(f"[{args.mode}] An error occurred while processing {media.title}: Path to mounted torrents does not exist: {mount_torrents_path}", e)
+                discordError(f"[{args.mode}] An error occurred while processing {media.title}: Path to mounted torrents does not exist", mount_torrents_path)
                 break
             # use a custom shell command or just count the subfolders within the mount to make sure the count is >0
             safety_check_command = os.getenv('MOUNT_SAFETY_CHECK_COMMAND', f'[ $(find {mount_torrents_path} -mindepth 1 -maxdepth 1 -type d | wc -l) -gt 0 ] && echo "true" || echo "false"')
@@ -84,7 +84,7 @@ def main():
 
                 if safety_check_failed:
                     print(f"Safety check failed: couldn't verify torrent folder is mounted: {mount_torrents_path}")
-                    discordError(f"[{args.mode}] An error occurred while processing {media.title}: Safety check failed: couldn't verify torrent folder is mounted: {mount_torrents_path}", e)
+                    discordError(f"[{args.mode}] An error occurred while processing {media.title}: Safety check failed: couldn't verify torrent folder is mounted", mount_torrents_path)
                     break
 
             except subprocess.CalledProcessError as e:

--- a/repair.py
+++ b/repair.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import argparse
 import time
 import traceback

--- a/shared/shared.py
+++ b/shared/shared.py
@@ -90,7 +90,7 @@ discord = {
 repair = {
     'repairInterval': env.string('REPAIR_REPAIR_INTERVAL', default=None),
     'runInterval': env.string('REPAIR_RUN_INTERVAL', default=None),
-    'safetyCheckScript': env.string('SAFETY_CHECK_SCRIPT', default="len([name for name in os.listdir(mountTorrentsPath) if os.path.isdir(os.path.join(mountTorrentsPath, name))]) > 0")
+    'safetyCheckScript': env.string('SAFETY_CHECK_SCRIPT', default='len([name for name in os.listdir(mountTorrentsPath) if os.path.isdir(os.path.join(mountTorrentsPath, name))]) > 0')
 }
 
 plexHeaders = {

--- a/shared/shared.py
+++ b/shared/shared.py
@@ -89,7 +89,8 @@ discord = {
 
 repair = {
     'repairInterval': env.string('REPAIR_REPAIR_INTERVAL', default=None),
-    'runInterval': env.string('REPAIR_RUN_INTERVAL', default=None)
+    'runInterval': env.string('REPAIR_RUN_INTERVAL', default=None),
+    'safetyCheckScript': env.string('SAFETY_CHECK_SCRIPT', default="len([name for name in os.listdir(mountTorrentsPath) if os.path.isdir(os.path.join(mountTorrentsPath, name))]) > 0")
 }
 
 plexHeaders = {


### PR DESCRIPTION
Added a check into each iteration of the outermost FOR loop to ensure that the torrent mount is up and functioning.  Since the mount could get dropped at any time, I thought it best to check each time it looped since there could be significant time between each one.  The command that is used can be overridden with the MOUNT_SAFETY_CHECK_COMMAND environment variable or will default to checking count > 0 for the folders within the mount.