### PR TITLE
Adds Torbox NZB support

### DIFF
--- a/blackhole_watcher.py
+++ b/blackhole_watcher.py
@@ -10,7 +10,7 @@ class BlackholeHandler(FileSystemEventHandler):
         self.path_name = getPath(is_radarr, create=True)
 
     def on_created(self, event):
-        if not event.is_directory and event.src_path.lower().endswith((".torrent", ".magnet")):
+        if not event.is_directory and event.src_path.lower().endswith((".torrent", ".magnet", ".nzb")):
             asyncio.run(on_created(self.is_radarr))
 
     async def on_run(self):


### PR DESCRIPTION
This PR does what the title says.

Main changes:
* Renames `TorrentBase` -> `FileBase`, and applies similar renaming to all methods
* Adds abstract `_addNZBFile()` method
* Adds `UsenetTorbox`, `TorboxNZB`, and `NZB` classes
* Updates `blackhole.py` to account for and process `.nzb` files in the watched directory

Tested with *arrs and Usenet BlackHole download client with the following settings (I'm using the same directories for torrents):
<img width="734" alt="Screenshot 2024-11-25 at 22 23 06" src="https://github.com/user-attachments/assets/93447c86-707c-4dc2-a668-acd576b44998">
