### PR TITLE
Prevent  error loop when file name is too long

### DIFF
--- a/blackhole.py
+++ b/blackhole.py
@@ -277,7 +277,16 @@ async def processFile(file: TorrentFileInfo, arr: Arr, isRadarr):
                     executor.shutdown(wait=False)
 
         time.sleep(.1) # Wait before processing the file in case it isn't fully written yet.
-        os.renames(file.fileInfo.filePath, file.fileInfo.filePathProcessing)
+        try:
+            os.renames(file.fileInfo.filePath, file.fileInfo.filePathProcessing)
+        except OSError as e:
+            if e.errno == 36: # File name too long
+                print(f"Error handling paths for {file.fileInfo.filenameWithoutExt}. Paths may be too long. Blacklisting.")
+                os.remove(file.fileInfo.filePath)
+                await fail(arr=arr, filename=file.fileInfo.filenameWithoutExt)
+                return False
+            raise
+
 
         with open(file.fileInfo.filePathProcessing, 'rb' if file.torrentInfo.isDotTorrentFile else 'r') as f:
             fileData = f.read()
@@ -315,21 +324,37 @@ async def processFile(file: TorrentFileInfo, arr: Arr, isRadarr):
 
         discordError(f"Error processing {file.fileInfo.filenameWithoutExt}", e)
 
-async def fail(torrent: TorrentBase, arr: Arr):
+async def fail(torrent: TorrentBase = None, arr: Arr = None, filename: str = None):
     _print = globals()['print']
 
     def print(*values: object):
-        _print(f"[{torrent.__class__.__name__}] [{torrent.file.fileInfo.filenameWithoutExt}]", *values)
+        source = torrent.file.fileInfo.filenameWithoutExt if torrent else filename
+        _print(f"[{torrent.__class__.__name__ if torrent else 'ValidationError'}] [{source}]", *values)
 
     print(f"Failing")
     
-    torrentHash = torrent.getHash()
-    history = await asyncio.to_thread(arr.getHistory, blackhole['historyPageSize'])
-    items = [item for item in history if (item.torrentInfoHash and item.torrentInfoHash.casefold() == torrentHash.casefold()) or cleanFileName(item.sourceTitle.casefold()) == torrent.file.fileInfo.filenameWithoutExt.casefold()]
+    torrentHash = torrent.getHash() if torrent else None
+    cleanName = cleanFileName(filename.casefold()) if filename else None
+
+    history = await asyncio.to_thread(arr.getHistory, blackhole['historyPageSize']) if arr else []
+
+    def matchesTorrent(item):
+        if torrentHash and item.torrentInfoHash and item.torrentInfoHash.casefold() == torrentHash.casefold():
+            return True
+        if torrent and cleanFileName(item.sourceTitle.casefold()) == torrent.file.fileInfo.filenameWithoutExt.casefold():
+            return True
+        return False
+
+    def matchesFilename(item):
+        if cleanName and cleanFileName(item.sourceTitle.casefold()) == cleanName:
+            return True
+        return False
+
+    items = [item for item in history if matchesTorrent(item) or matchesFilename(item)]
     if not items:
         message = "No history items found to mark as failed. Arr will not attempt to grab an alternative."
         print(message)
-        discordError(message, torrent.file.fileInfo.filenameWithoutExt)
+        discordError(message, torrent.file.fileInfo.filenameWithoutExt if torrent else filename)
     else:
         # TODO: See if we can fail without blacklisting as cached items constantly changes
         failTasks = [asyncio.to_thread(arr.failHistoryItem, item.id) for item in items]


### PR DESCRIPTION
Some file names can exceed python's 255 path limit. Currently this causes blackhole to go into an infinite error loop.
I made the following changes:
- Adjusted the `fail` method to take in either a torrent or a filename
- Catch the "file name too long" error when it happens (other errors are raised)
- Fail and blacklist the torrent when the name is too long

This is the cleanest solution I could think of.

## Before
![image](https://github.com/user-attachments/assets/2b1e311c-1986-4963-a638-5db385a5918b)

## After

https://github.com/user-attachments/assets/c35b4929-141e-4d39-9c9a-8981d016300e

