### PR TITLE
🐛 Bugfix: Incorrect file filtering for Sonarr when `seasonNumber == seriesId`

### DIFF
--- a/shared/arr.py
+++ b/shared/arr.py
@@ -287,15 +287,9 @@ class Arr(ABC):
     def put(self, media: Media):
         retryRequest(lambda: requests.put(f"{self.host}/api/v3/{self.endpoint}/{media.id}?apiKey={self.apiKey}&moveFiles=true", json=media.json))
 
-    def getFiles(self, media: Media, childId: int=None):
+    def getFiles(self, media: Media, childId: int = None):
         response = retryRequest(lambda: requests.get(f"{self.host}/api/v3/{self.fileEndpoint}?apiKey={self.apiKey}&{self.endpoint}Id={media.id}"))
-
-        files = map(self.fileConstructor, response.json())
-
-        if childId != None and childId != media.id:
-            files = filter(lambda file: file.parentId == childId, files)
-
-        return files
+        return map(self.fileConstructor, response.json())
 
     def deleteFiles(self, files: List[MediaFile]):
         fileIds = [file.id for file in files]
@@ -349,6 +343,12 @@ class Sonarr(Arr):
 
     def _automaticSearchJson(self, media: Media, childId: int):
         return {"name": f"{self.childName}Search", f"{self.endpoint}Id": media.id, self.childIdName: childId}
+    
+    def getFiles(self, media: Media, childId: int = None):
+        files = super().getFiles(media)
+        if childId is not None:
+            files = filter(lambda file: file.parentId == childId, files)
+        return files
 
 class Radarr(Arr):
     host = radarr['host']


### PR DESCRIPTION
## 🐛 Bugfix: Incorrect file filtering in `getFiles` method for Sonarr when `seasonNumber == id`

### Problem
The `getFiles` method in the `Arr` class behaved incorrectly for **Sonarr** when the `seasonNumber` matched the series `id`. In such cases, it returned **all episode files for the entire series**, instead of just the files for the requested season.

This issue was isolated to the `getFiles` method — no other logic or behavior in Sonarr or Radarr was affected.

### Changes
- ✅ **Moved** filtering logic into the `Sonarr` class to properly handle Sonarr-specific behavior.
- ✅ Left `Radarr` behavior untouched, as it does not require filtering.
- ✅ **Standardized** the `getFiles(media: Media, childId: int = None)` method signature in the base `Arr` class to ensure consistent usage and avoid `TypeError`.

### Impact
This change ensures the `getFiles` method returns only the correct season’s files for Sonarr, even when `seasonNumber == id`.

Previously, this bug would cause repair to **check and process all seasons except the one with id twice** — once directly by `seasonNumber`, and again when the full-series files were returned due to the ID match.

Other methods and features are unaffected — this fix is strictly scoped to `getFiles`.
